### PR TITLE
fix: クイズ・結果画面がサイドバーに隠れる問題 (#49)

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta name="theme-color" content="#0a0e1a">
   <link rel="manifest" href="manifest.json">
   <title>JCSQE初級 合格対策アプリ</title>
-  <link rel="stylesheet" href="style.css?v=13">
+  <link rel="stylesheet" href="style.css?v=14">
 </head>
 <body>
   <div id="sync-toast" class="sync-toast hidden" role="status" aria-live="polite"></div>
@@ -30,6 +30,52 @@
       <span>設定</span>
     </button>
   </nav>
+
+  <!-- クイズ・結果は .app の外（nav と同レベル）に置き、z-index がサイドバーより効くようにする (#49) -->
+  <div id="quiz" class="screen full-screen">
+    <button class="btn btn-secondary btn-back" onclick="switchTab('tab-home')">← やめる</button>
+    <div class="text-center mb-20 hidden" id="quiz-timer-box">
+      <div class="timer" id="quiz-timer">60:00</div>
+    </div>
+    <div class="card">
+      <div class="quiz-header">
+        <span class="quiz-progress" id="quiz-progress">1 / 10</span>
+        <span class="quiz-tag" id="quiz-tag"></span>
+        <button class="bookmark-btn" id="quiz-bookmark" onclick="toggleBookmark()" title="ブックマーク">☆</button>
+        <span class="quiz-level" id="quiz-level">L1</span>
+      </div>
+      <div class="progress-bar"><div class="progress-fill" id="quiz-bar" style="width:0%"></div></div>
+      <p class="quiz-question" id="quiz-question"></p>
+      <div class="choices" id="quiz-choices"></div>
+      <div id="quiz-explanation" class="explanation hidden">
+        <h4>💡 解説</h4>
+        <div id="quiz-explanation-text"></div>
+      </div>
+      <div class="mt-20 text-center hidden" id="quiz-next-box" style="text-align:right;">
+        <button class="btn btn-primary btn-sm" onclick="nextQuestion()" id="quiz-next-btn">次の問題 →</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="result" class="screen full-screen">
+    <div class="card result-card">
+      <h2 style="margin-bottom:20px;">📝 結果</h2>
+      <div class="result-score" id="result-score">80%</div>
+      <div class="result-label" id="result-detail">32 / 40 正解</div>
+      <div id="result-pass" class="result-pass hidden">合格ライン達成！</div>
+      <div class="chapter-stats mt-20" id="result-chapter-stats"></div>
+      <div class="result-review mt-20">
+        <h3 style="margin-bottom:12px;">📚 復習ガイド</h3>
+        <div id="result-review-summary" class="result-review-summary"></div>
+        <div id="result-wrong-list" class="result-wrong-list"></div>
+      </div>
+      <div class="flex-row mt-20" style="flex-direction:column; gap:12px;">
+        <button class="btn btn-primary btn-block" id="result-retry-btn" onclick="retryQuiz()" style="justify-content:center;">🔄 もう一度解く</button>
+        <button class="btn btn-secondary btn-block hidden" id="result-retry-wrong-btn" style="justify-content:center;">📚 間違えた問題を復習</button>
+        <button class="btn btn-secondary btn-block" onclick="switchTab('tab-home')" style="justify-content:center;">🏠 ホームへ戻る</button>
+      </div>
+    </div>
+  </div>
 
   <div class="app">
 
@@ -235,52 +281,6 @@
       <div class="flex-row" style="margin-top:20px;">
         <button type="button" class="btn btn-secondary btn-block" style="justify-content:center;" onclick="closeQuestionCountModal()">キャンセル</button>
         <button type="button" class="btn btn-primary btn-block" style="justify-content:center;" onclick="confirmQuestionCountModal()">開始</button>
-      </div>
-    </div>
-  </div>
-
-  <!-- ================= クイズ・結果画面 (フルスクリーン) ================= -->
-  <div id="quiz" class="screen full-screen">
-    <button class="btn btn-secondary btn-back" onclick="switchTab('tab-home')">← やめる</button>
-    <div class="text-center mb-20 hidden" id="quiz-timer-box">
-      <div class="timer" id="quiz-timer">60:00</div>
-    </div>
-    <div class="card">
-      <div class="quiz-header">
-        <span class="quiz-progress" id="quiz-progress">1 / 10</span>
-        <span class="quiz-tag" id="quiz-tag"></span>
-        <button class="bookmark-btn" id="quiz-bookmark" onclick="toggleBookmark()" title="ブックマーク">☆</button>
-        <span class="quiz-level" id="quiz-level">L1</span>
-      </div>
-      <div class="progress-bar"><div class="progress-fill" id="quiz-bar" style="width:0%"></div></div>
-      <p class="quiz-question" id="quiz-question"></p>
-      <div class="choices" id="quiz-choices"></div>
-      <div id="quiz-explanation" class="explanation hidden">
-        <h4>💡 解説</h4>
-        <div id="quiz-explanation-text"></div>
-      </div>
-      <div class="mt-20 text-center hidden" id="quiz-next-box" style="text-align:right;">
-        <button class="btn btn-primary btn-sm" onclick="nextQuestion()" id="quiz-next-btn">次の問題 →</button>
-      </div>
-    </div>
-  </div>
-
-  <div id="result" class="screen full-screen">
-    <div class="card result-card">
-      <h2 style="margin-bottom:20px;">📝 結果</h2>
-      <div class="result-score" id="result-score">80%</div>
-      <div class="result-label" id="result-detail">32 / 40 正解</div>
-      <div id="result-pass" class="result-pass hidden">合格ライン達成！</div>
-      <div class="chapter-stats mt-20" id="result-chapter-stats"></div>
-      <div class="result-review mt-20">
-        <h3 style="margin-bottom:12px;">📚 復習ガイド</h3>
-        <div id="result-review-summary" class="result-review-summary"></div>
-        <div id="result-wrong-list" class="result-wrong-list"></div>
-      </div>
-      <div class="flex-row mt-20" style="flex-direction:column; gap:12px;">
-        <button class="btn btn-primary btn-block" id="result-retry-btn" onclick="retryQuiz()" style="justify-content:center;">🔄 もう一度解く</button>
-        <button class="btn btn-secondary btn-block hidden" id="result-retry-wrong-btn" style="justify-content:center;">📚 間違えた問題を復習</button>
-        <button class="btn btn-secondary btn-block" onclick="switchTab('tab-home')" style="justify-content:center;">🏠 ホームへ戻る</button>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -928,6 +928,14 @@ body[data-theme="light"] .header h1 {
   animation: fadeSlideUp 0.3s ease !important;
 }
 
+/* デスクトップ: クイズ/結果表示中はサイドバーをオーバーレイより下に (#49) */
+@media (min-width: 768px) {
+  body:has(#quiz.screen.active) .app-nav,
+  body:has(#result.screen.active) .app-nav {
+    z-index: 1000;
+  }
+}
+
 /* Adjusting Print for UI v3 */
 @media print {
   .app-nav { display: none !important; }

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -23,6 +23,18 @@ test.describe('JCSQE学習アプリ E2E', () => {
     await expect(page.locator('.quiz-question')).toBeVisible();
   });
 
+  test('デスクトップでクイズ表示時、左端（サイドバー位置）の最前面がクイズで問題文が隠れない (#49)', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/', { waitUntil: 'load' });
+    await clickNavCard(page, 'nav-daily');
+    await expect(page.locator('#quiz.screen.active')).toBeVisible({ timeout: 5000 });
+    const hitIsQuiz = await page.evaluate(() => {
+      const el = document.elementFromPoint(48, 360);
+      return !!(el && el.closest('#quiz'));
+    });
+    expect(hitIsQuiz).toBe(true);
+  });
+
   test('1問解答すると解説が表示される', async ({ page }) => {
     await page.goto('/', { waitUntil: 'load' });
     await clickNavCard(page, 'nav-daily');


### PR DESCRIPTION
## 概要

Issue #49（デスクトップでクイズ・結果画面が左サイドバーの下にめり込む）を修正する。

## 変更内容

- `index.html`: `#quiz` / `#result` を `nav` 直後（`div.app` より前）に移動
- `style.css`: 768px 以上でクイズ／結果表示中は `body:has(...)` により `.app-nav` の `z-index` を下げ、`.full-screen` が確実に手前になるよう調整
- `tests/e2e.spec.js`: ビューポート 1280×720 で `elementFromPoint(48, 360)` が `#quiz` 配下であることを検証

## 確認

- `npm test` 合格
- `npm run test:e2e` 合格（5 tests passed）

Closes #49
