### PR TITLE
feat(sync): JCSQE 専用 Cloudflare D1 Sync Worker と設定タブ UI (#73)

### DIFF
--- a/.github/workflows/deploy-jcsqe-sync-worker.yml
+++ b/.github/workflows/deploy-jcsqe-sync-worker.yml
@@ -1,0 +1,100 @@
+# cloudflare/jcsqe-sync-worker を master へ push したときに自動デプロイ。
+# 初回のみ: Cloudflare で D1 を作成し、リポジトリ Secrets を設定する（README 参照）。
+name: Deploy JCSQE Sync Worker
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - 'cloudflare/jcsqe-sync-worker/**'
+      - '.github/workflows/deploy-jcsqe-sync-worker.yml'
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: cloudflare/jcsqe-sync-worker
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: cloudflare/jcsqe-sync-worker/package-lock.json
+
+      - name: Check required secrets
+        id: gate
+        run: |
+          if [ -z "$D1_ID" ] || [ -z "$CF_TOKEN" ] || [ -z "$CF_ACCOUNT" ] || [ -z "$FB_PID" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Worker deploy skipped. Set repository secrets: D1_DATABASE_ID, CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, FIREBASE_PROJECT_ID (see cloudflare/jcsqe-sync-worker/README.md)."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          D1_ID: ${{ secrets.D1_DATABASE_ID }}
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          FB_PID: ${{ secrets.FIREBASE_PROJECT_ID }}
+
+      # スキップ時もジョブが「成功（緑）」になると Worker が無いのに誤解されるため、明示的に失敗させる
+      - name: Fail if deploy was skipped (secrets missing at run time)
+        if: steps.gate.outputs.skip == 'true'
+        run: |
+          echo "::error::デプロイは実行されませんでした。D1_DATABASE_ID / CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID / FIREBASE_PROJECT_ID を Repository secrets に入れたうえで、このワークフローを再実行してください。"
+          exit 1
+
+      - name: Patch wrangler.toml with D1 database id
+        if: steps.gate.outputs.skip != 'true'
+        run: sed -i "s/REPLACE_WITH_WRANGLER_D1_CREATE_OUTPUT/$D1_DATABASE_ID/g" wrangler.toml
+        env:
+          D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
+
+      - name: Patch wrangler.toml with Firebase project id
+        if: steps.gate.outputs.skip != 'true'
+        run: sed -i "s/REPLACE_WITH_FIREBASE_PROJECT_ID/$FIREBASE_PROJECT_ID/g" wrangler.toml
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+
+      - name: Install dependencies
+        if: steps.gate.outputs.skip != 'true'
+        run: npm ci
+
+      - name: Apply D1 migrations (remote)
+        if: steps.gate.outputs.skip != 'true'
+        run: npx wrangler d1 migrations apply jcsqe-study-data --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Upload SYNC_API_SECRET to Worker
+        if: steps.gate.outputs.skip != 'true'
+        run: |
+          if [ -z "$JCSQE_SYNC_API_SECRET" ]; then
+            echo "::warning::JCSQE_SYNC_API_SECRET is empty; skipping wrangler secret put. Set the secret and re-run workflow."
+            exit 0
+          fi
+          printf '%s' "$JCSQE_SYNC_API_SECRET" | npx wrangler secret put SYNC_API_SECRET
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          JCSQE_SYNC_API_SECRET: ${{ secrets.JCSQE_SYNC_API_SECRET }}
+
+      - name: Deploy Worker
+        if: steps.gate.outputs.skip != 'true'
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 このプロジェクトの注目すべき変更はこのファイルに記録されます。
 
+## [1.2.24] - 2026-04-19
+
+### 追加
+- **JCSQE 専用 Cloudflare D1 Sync Worker**（[#73](https://github.com/junichi-muraoka/jcsqe-study-app/issues/73)）: 学習データを Firebase Firestore に加えて **JCSQE 専用 D1**（[ut-qms / Qraft](https://github.com/junichi-muraoka/ut-qms) の D1 とは別インスタンス）にも保存できる任意経路を追加。Google ログイン中のみ **Firebase ID トークン**を `Authorization: Bearer` で送り、Worker は Google JWKS で検証、`sub`（Firebase UID）を D1 の行キーにする。設定タブに ☁️ Cloudflare D1 同期カードを追加し、`saveData` ごとにデバウンス PUT／手動 Pull が可能。運用者は `js/d1-sync-config.js` に Worker URL を 1 行書くだけで有効化でき、**エンドユーザーは URL もトークンも入力しない**。
+- **`.github/workflows/deploy-jcsqe-sync-worker.yml`**: `cloudflare/jcsqe-sync-worker/` 変更時に自動デプロイ。必要 Secrets（`D1_DATABASE_ID` / `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` / `FIREBASE_PROJECT_ID`）が未設定のときは明示的に fail する。
+- **`scripts/verify-oauth-client.js`** + テスト: GitHub Secret `GOOGLE_OAUTH_CLIENT_ID` と `firebase-config.js` 内の `J.googleOAuthClientId` の突合。`--remote` で Pages にデプロイされた JS を検証可能。
+
+### ドキュメント
+- [docs/jcsqe_cloudflare_d1_sync.md](docs/jcsqe_cloudflare_d1_sync.md) / [cloudflare/jcsqe-sync-worker/README.md](cloudflare/jcsqe-sync-worker/README.md) を新設。
+
+---
+
 ## [1.2.23] - 2026-03-28
 
 ### 変更（CI / 本番デプロイ）

--- a/cloudflare/jcsqe-sync-worker/.dev.vars.example
+++ b/cloudflare/jcsqe-sync-worker/.dev.vars.example
@@ -1,0 +1,5 @@
+# wrangler dev 用。コピーして .dev.vars にし、値を入れる（.dev.vars は Git 対象外）
+# Firebase コンソールの project ID（js/firebase-config.js の projectId と一致）
+FIREBASE_PROJECT_ID=your-firebase-project-id
+# 任意: 旧クライアント（Bearer 共有シークレット）用。通常は空でよい
+SYNC_API_SECRET=

--- a/cloudflare/jcsqe-sync-worker/.gitignore
+++ b/cloudflare/jcsqe-sync-worker/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.wrangler/
+.dev.vars
+*.log

--- a/cloudflare/jcsqe-sync-worker/README.md
+++ b/cloudflare/jcsqe-sync-worker/README.md
@@ -1,0 +1,87 @@
+# JCSQE 学習データ同期 Worker（専用 D1）
+
+[ut-qms](https://github.com/junichi-muraoka/ut-qms) の D1 とは **別のデータベース**・**別 Worker** として動かすための最小 API です。
+
+## 前提
+
+- Cloudflare アカウントと [Wrangler](https://developers.cloudflare.com/workers/wrangler/install-and-update/) が使えること
+- Node.js が入っていること
+- Firebase と **同じ project ID**（Web アプリの `js/firebase-config.js` の `projectId` と一致）
+
+## 初回セットアップ
+
+```bash
+cd cloudflare/jcsqe-sync-worker
+npm install
+```
+
+### 1. D1 を新規作成（JCSQE 専用）
+
+```bash
+npx wrangler d1 create jcsqe-study-data
+```
+
+表示された `database_id` を `wrangler.toml` の `database_id` に貼り付ける（`REPLACE_WITH_WRANGLER_D1_CREATE_OUTPUT` を置換）。
+
+### 2. Firebase project ID を `wrangler.toml` に書く
+
+`[vars]` の `FIREBASE_PROJECT_ID` を、Firebase コンソールの **project ID**（公開情報）に置き換える。GitHub Actions 利用時は Repository secret `FIREBASE_PROJECT_ID` で CI が置換する。
+
+### 3. マイグレーション適用
+
+```bash
+npx wrangler d1 migrations apply jcsqe-study-data --local   # ローカル SQLite
+npx wrangler d1 migrations apply jcsqe-study-data --remote  # リモート D1
+```
+
+### 4. ローカル開発用の変数（任意）
+
+`.dev.vars.example` を `.dev.vars` にコピーし、`FIREBASE_PROJECT_ID` を入れる（`wrangler dev` 用）。
+
+### 5. 旧クライアント用シークレット（任意）
+
+従来の **Bearer 共有シークレット + `X-User-Id`** だけ使う場合のみ:
+
+```bash
+npx wrangler secret put SYNC_API_SECRET
+```
+
+通常のフロント（Firebase ID トークン認証）では **不要**。
+
+## 開発・デプロイ
+
+```bash
+npm run dev      # ローカル
+npm run deploy   # Cloudflare へデプロイ
+```
+
+デプロイ後の URL（例: `https://jcsqe-study-sync.<account>.workers.dev`）に対し:
+
+- `GET /api/health` … 疎通確認
+- `GET /api/study` … `Authorization: Bearer <Firebase ID トークン>`（ログインユーザーの JWT）。主キーはトークン内の `sub`（Firebase UID）
+- `PUT /api/study` … ボディ `{"data":{...}}`（学習データオブジェクト）。同上の Bearer
+
+**レガシー**（移行用）: `Authorization: Bearer <SYNC_API_SECRET>` と `X-User-Id: <uuid>` の組み合わせも受理する。
+
+## フロント（Cloudflare Pages）から呼ぶとき
+
+- **エンドユーザーは URL もトークンも入力しません。** 運用者がリポジトリの `js/d1-sync-config.js` に **Worker のベース URL だけ** 1 度書き、コミット・デプロイします。
+- ユーザーは **Google でログイン**（Firebase Auth）すれば、ブラウザが **ID トークン**を Worker に送ります。
+- CORS はデフォルトで `https://jcsqe-study-app.pages.dev` と localhost。別オリジンなら `ALLOWED_ORIGIN` を `wrangler.toml` の `[vars]` かダッシュボードで変更
+
+## GitHub Actions で自動デプロイ（推奨）
+
+`master` へ `cloudflare/jcsqe-sync-worker/` の変更が push されると [.github/workflows/deploy-jcsqe-sync-worker.yml](../../.github/workflows/deploy-jcsqe-sync-worker.yml) が動きます。次の **Repository secrets** を設定しておくこと（いずれか欠けるとジョブは失敗します）。
+
+| Secret | 説明 |
+|--------|------|
+| `D1_DATABASE_ID` | `npx wrangler d1 create jcsqe-study-data` の出力 UUID（`wrangler.toml` のプレースホルダを CI が置換） |
+| `CLOUDFLARE_API_TOKEN` | Workers / D1 用 API トークン |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare の Account ID |
+| `FIREBASE_PROJECT_ID` | Firebase の project ID（`wrangler.toml` の `FIREBASE_PROJECT_ID` を CI が置換） |
+| `JCSQE_SYNC_API_SECRET` | 任意。レガシー API 用。空なら `wrangler secret put SYNC_API_SECRET` はスキップ |
+
+## セキュリティ注意
+
+- フロントに **共有シークレットを持たせない**構成です。Worker は Google の JWKS で **Firebase ID トークン**を検証し、`sub` を D1 のユーザー主キーにします。
+- 旧 PoC の `SYNC_API_SECRET` は、互換用に残していますが、公開アプリでは Firebase 認証のみを推奨します。

--- a/cloudflare/jcsqe-sync-worker/migrations/0001_init.sql
+++ b/cloudflare/jcsqe-sync-worker/migrations/0001_init.sql
@@ -1,0 +1,8 @@
+-- JCSQE 専用 D1（ut-qms の DB とは別インスタンスでバインドする）
+CREATE TABLE study_snapshots (
+  user_id TEXT PRIMARY KEY,
+  payload TEXT NOT NULL,
+  updated_at_ms INTEGER NOT NULL
+);
+
+CREATE INDEX idx_study_snapshots_updated ON study_snapshots(updated_at_ms);

--- a/cloudflare/jcsqe-sync-worker/package-lock.json
+++ b/cloudflare/jcsqe-sync-worker/package-lock.json
@@ -1,0 +1,1628 @@
+{
+  "name": "jcsqe-study-sync-worker",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jcsqe-study-sync-worker",
+      "version": "0.1.0",
+      "dependencies": {
+        "hono": "^4.6.0",
+        "jose": "^5.10.0"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20241230.0",
+        "typescript": "^5.7.0",
+        "wrangler": "^3.99.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
+      "integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.14",
+        "workerd": "^1.20250124.0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250718.0.tgz",
+      "integrity": "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250718.0.tgz",
+      "integrity": "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250718.0.tgz",
+      "integrity": "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260329.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260329.1.tgz",
+      "integrity": "sha512-LxBHrYYI/AZ6OCbUzRqRgg6Rt1qev2KxN2NNd3saye41AO2g52cYvHV+ohts5oPnrIUD7YRjbgN/J3NU7e7m5A==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/hono": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "3.20250718.3",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.3.tgz",
+      "integrity": "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "8.14.0",
+        "acorn-walk": "8.3.2",
+        "exit-hook": "2.2.1",
+        "glob-to-regexp": "0.4.1",
+        "stoppable": "1.1.0",
+        "undici": "^5.28.5",
+        "workerd": "1.20250718.0",
+        "ws": "8.18.0",
+        "youch": "3.3.4",
+        "zod": "3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stacktracey": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
+      "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "exsolve": "^1.0.1",
+        "ohash": "^2.0.10",
+        "pathe": "^2.0.3",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz",
+      "integrity": "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20250718.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250718.0",
+        "@cloudflare/workerd-linux-64": "1.20250718.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250718.0",
+        "@cloudflare/workerd-windows-64": "1.20250718.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "3.114.17",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.17.tgz",
+      "integrity": "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@cloudflare/unenv-preset": "2.0.2",
+        "@esbuild-plugins/node-globals-polyfill": "0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "0.2.2",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20250718.3",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.14",
+        "workerd": "1.20250718.0"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2",
+        "sharp": "^0.33.5"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20250408.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.1",
+        "mustache": "^4.2.0",
+        "stacktracey": "^2.1.8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/cloudflare/jcsqe-sync-worker/package.json
+++ b/cloudflare/jcsqe-sync-worker/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "jcsqe-study-sync-worker",
+  "private": true,
+  "version": "0.1.0",
+  "description": "JCSQE 学習データ同期 API（Cloudflare Worker + 専用 D1）",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "cf-typegen": "wrangler types"
+  },
+  "dependencies": {
+    "hono": "^4.6.0",
+    "jose": "^5.10.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20241230.0",
+    "typescript": "^5.7.0",
+    "wrangler": "^3.99.0"
+  }
+}

--- a/cloudflare/jcsqe-sync-worker/src/index.ts
+++ b/cloudflare/jcsqe-sync-worker/src/index.ts
@@ -1,0 +1,171 @@
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+
+export interface Env {
+  DB: D1Database;
+  /** 旧クライアント用（Bearer が共有シークレットのとき）。新フロントは Firebase ID トークンのみ */
+  SYNC_API_SECRET?: string;
+  /** Firebase コンソールの project ID（公開情報）。ID トークンの aud / iss 検証に使用 */
+  FIREBASE_PROJECT_ID?: string;
+  ALLOWED_ORIGIN?: string;
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+const JWKS = createRemoteJWKSet(
+  new URL('https://www.googleapis.com/oauth2/v3/certs')
+);
+
+const DEFAULT_PAGES_ORIGINS = [
+  'https://jcsqe-study-app.pages.dev',
+  'https://jcsqe-study-app-staging.pages.dev',
+];
+
+function allowedOrigins(env: Env): string[] {
+  const raw = env.ALLOWED_ORIGIN?.trim();
+  if (raw) {
+    return raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return DEFAULT_PAGES_ORIGINS;
+}
+
+app.use(
+  '*',
+  cors({
+    origin: (origin, c) => {
+      const list = allowedOrigins(c.env);
+      const fallback = list[0] ?? DEFAULT_PAGES_ORIGINS[0];
+      if (!origin) return fallback;
+      if (list.includes(origin)) return origin;
+      if (/^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) {
+        return origin;
+      }
+      return fallback;
+    },
+    allowHeaders: ['Authorization', 'X-User-Id', 'Content-Type'],
+    allowMethods: ['GET', 'PUT', 'OPTIONS'],
+  })
+);
+
+function unauthorized() {
+  return new Response(JSON.stringify({ error: 'unauthorized' }), {
+    status: 401,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function verifyFirebaseUid(
+  token: string,
+  projectId: string
+): Promise<string | null> {
+  try {
+    const { payload } = await jwtVerify(token, JWKS, {
+      issuer: `https://securetoken.google.com/${projectId}`,
+      audience: projectId,
+    });
+    const sub = payload.sub;
+    return typeof sub === 'string' && sub ? sub : null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveUserId(c: {
+  req: { header: (n: string) => string | undefined };
+  env: Env;
+}): Promise<string | null> {
+  const auth = c.req.header('Authorization');
+  if (!auth?.startsWith('Bearer ')) return null;
+  const token = auth.slice(7).trim();
+  if (!token) return null;
+
+  const projectId = c.env.FIREBASE_PROJECT_ID?.trim();
+  if (projectId) {
+    const uid = await verifyFirebaseUid(token, projectId);
+    if (uid) return uid;
+  }
+
+  const legacySecret = c.env.SYNC_API_SECRET;
+  const userId = c.req.header('X-User-Id');
+  if (
+    legacySecret &&
+    token === legacySecret &&
+    userId &&
+    userId.length > 0 &&
+    userId.length <= 128
+  ) {
+    return userId.trim();
+  }
+  return null;
+}
+
+app.get('/api/health', (c) =>
+  c.json({ ok: true, service: 'jcsqe-study-sync' })
+);
+
+app.get('/api/study', async (c) => {
+  const userId = await resolveUserId(c);
+  if (!userId) return unauthorized();
+
+  const row = await c.env.DB.prepare(
+    'SELECT payload, updated_at_ms FROM study_snapshots WHERE user_id = ?'
+  )
+    .bind(userId)
+    .first<{ payload: string; updated_at_ms: number }>();
+
+  if (!row) {
+    return c.json({ data: null, updatedAtMs: null });
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(row.payload);
+  } catch {
+    return c.json({ error: 'invalid_payload' }, 500);
+  }
+
+  return c.json({ data, updatedAtMs: row.updated_at_ms });
+});
+
+app.put('/api/study', async (c) => {
+  const userId = await resolveUserId(c);
+  if (!userId) return unauthorized();
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_json' }, 400);
+  }
+
+  if (!body || typeof body !== 'object' || !('data' in body)) {
+    return c.json(
+      { error: 'expected_shape', detail: '{ "data": <study object> }' },
+      400
+    );
+  }
+
+  const payload = JSON.stringify((body as { data: unknown }).data);
+  if (payload.length > 1_500_000) {
+    return c.json({ error: 'payload_too_large' }, 413);
+  }
+
+  const now = Date.now();
+  await c.env.DB.prepare(
+    `INSERT INTO study_snapshots (user_id, payload, updated_at_ms)
+     VALUES (?, ?, ?)
+     ON CONFLICT(user_id) DO UPDATE SET
+       payload = excluded.payload,
+       updated_at_ms = excluded.updated_at_ms`
+  )
+    .bind(userId, payload, now)
+    .run();
+
+  return c.json({ ok: true, updatedAtMs: now });
+});
+
+export default app;

--- a/cloudflare/jcsqe-sync-worker/tsconfig.json
+++ b/cloudflare/jcsqe-sync-worker/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/cloudflare/jcsqe-sync-worker/wrangler.toml
+++ b/cloudflare/jcsqe-sync-worker/wrangler.toml
@@ -1,0 +1,19 @@
+# JCSQE 専用 Worker + 専用 D1（ut-qms / Qraft の D1 とは別インスタンスで作成すること）
+name = "jcsqe-study-sync"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+
+# 初回: wrangler d1 create jcsqe-study-data
+# 出力された database_id を下記に貼り付ける
+[[d1_databases]]
+binding = "DB"
+database_name = "jcsqe-study-data"
+database_id = "REPLACE_WITH_WRANGLER_D1_CREATE_OUTPUT"
+
+[vars]
+# ALLOWED_ORIGIN は省略可（コード既定で本番・STG の *.pages.dev を許可）。カンマ区切りで複数指定可。
+# Firebase コンソールの project ID（js/firebase-config.js の projectId と一致させる）
+# CI では Repository secret FIREBASE_PROJECT_ID で sed 置換される
+FIREBASE_PROJECT_ID = "REPLACE_WITH_FIREBASE_PROJECT_ID"
+
+# SYNC_API_SECRET は任意（旧クライアントのみ）。wrangler secret put SYNC_API_SECRET

--- a/docs/jcsqe_cloudflare_d1_sync.md
+++ b/docs/jcsqe_cloudflare_d1_sync.md
@@ -1,0 +1,59 @@
+# JCSQE 学習データの Cloudflare 同期（専用 D1 + 専用 Worker）
+
+## 1. 目的
+
+学習データを **ブラウザ以外**にも保持する場合の、**Cloudflare 上の保存先**の考え方です。  
+[ut-qms（Qraft）](https://github.com/junichi-muraoka/ut-qms) の DB とは **別アプリとして分離**します。
+
+## 2. 分離の方針（結論）
+
+| 項目 | 方針 |
+|------|------|
+| **データベース** | **JCSQE 専用の D1**（ut-qms の D1 とは **別インスタンス**） |
+| **API** | **JCSQE 専用の Cloudflare Worker**（本リポジトリの `cloudflare/jcsqe-sync-worker/`） |
+| **フロント** | 引き続き GitHub Pages の静的アプリ（別オリジンから `fetch`） |
+
+同じ Cloudflare アカウントに **DB が 2 つ**並ぶイメージです。QMS 用と JCSQE 用で **中身が混ざりません**。
+
+## 3. ut-qms との関係
+
+- **コードの置き場所**: 学習同期用 Worker は **本リポジトリ**に置き、ut-qms リポジトリには依存しません。
+- **運用**: デプロイ・シークレット・D1 バックアップは **JCSQE 用 Worker と D1** 単位で管理できます。
+- **将来**: 認証や監視を ut-qms と揃えたくなったら、**OAuth やダッシュボード**だけパターンを合わせる、という段階が可能です。
+
+## 4. フロントエンドとの接続（実装済み）
+
+- **エンドユーザーは Worker URL や API トークンを入力しません。** 運用者が `js/d1-sync-config.js` に **Worker のベース URL だけ** 記載します（`d1-sync-config.example.js` を参照）。
+- **Google でログイン**（Firebase Auth）しているとき、ブラウザは **Firebase ID トークン**を `Authorization: Bearer` で送ります。Worker は Google の JWKS で検証し、トークンの `sub`（Firebase UID）を D1 の行キーにします。
+- **設定**タブで「保存時に自動で Cloudflare に同期する」を有効にすると、**学習データを保存するたび**（`saveData`）に **自動で PUT** します（デバウンス約 3.5 秒）。
+- **クラウドから取得**で `GET` し、ローカルに上書き反映します（`js/d1-sync.js`）。
+- CORS は GitHub Pages 想定で Worker 側に設定済み（`ALLOWED_ORIGIN` で変更可）。
+
+## 4.1 GitHub Actions で Worker を自動デプロイ
+
+リポジトリに次の **Secrets** を入れておくと、`cloudflare/jcsqe-sync-worker/` が `master` にマージされたとき **[Deploy JCSQE Sync Worker](https://github.com/junichi-muraoka/jcsqe-study-app/actions)** が **マイグレーション適用 →（任意でレガシー secret）→ deploy** まで実行します。
+
+| Secret | 内容 |
+|--------|------|
+| `D1_DATABASE_ID` | `wrangler d1 create jcsqe-study-data` で表示された UUID |
+| `CLOUDFLARE_API_TOKEN` | Workers + D1 権限の API トークン |
+| `CLOUDFLARE_ACCOUNT_ID` | ダッシュボードの Account ID |
+| `FIREBASE_PROJECT_ID` | Firebase の project ID（Worker の JWT 検証用。`firebase-config.js` の `projectId` と一致） |
+| `JCSQE_SYNC_API_SECRET` | 任意。旧 Bearer 方式用。空なら `wrangler secret put` はスキップ |
+
+## 5. 認証モデル
+
+- **`Authorization: Bearer <Firebase ID トークン>`** … Worker が JWKS で検証。`sub` を `user_id` に使用。
+- **レガシー（互換）**: `Authorization: Bearer <SYNC_API_SECRET>` と **`X-User-Id`** … 旧 PoC 用。
+
+## 6. 関連ファイル
+
+| パス | 内容 |
+|------|------|
+| [cloudflare/jcsqe-sync-worker/README.md](../cloudflare/jcsqe-sync-worker/README.md) | 作成・マイグレーション・デプロイ手順 |
+| [cloudflare/jcsqe-sync-worker/migrations/0001_init.sql](../cloudflare/jcsqe-sync-worker/migrations/0001_init.sql) | D1 スキーマ |
+
+## 7. 既存ドキュメントとの関係
+
+- **Firebase 同期**: [09_cloud_sync_firebase_spec.md](./09_cloud_sync_firebase_spec.md)（別経路。併存は可能だが、二重同期のルールは要設計）。
+- **データ形状**: [02_data_model.md](./02_data_model.md)

--- a/index.html
+++ b/index.html
@@ -281,6 +281,20 @@
           <button type="button" class="btn btn-secondary btn-block hidden" id="firebase-signout-btn" style="justify-content:center;">ログアウト</button>
         </div>
 
+        <div class="card" id="d1-sync-card">
+          <h3 style="margin-bottom:8px;">☁️ Cloudflare D1 同期（任意）</h3>
+          <p style="font-size:0.85rem;color:var(--text-secondary);line-height:1.6;margin-bottom:12px;">
+            Firebase に加えて、学習データを <strong>JCSQE 専用の Cloudflare D1</strong> にもバックアップします。Google ログイン中のみ有効です（運用者が Worker の URL を設定している場合に動作）。
+          </p>
+          <p id="d1-sync-status" style="font-size:0.8rem;color:var(--text-muted);margin-bottom:12px;"></p>
+          <label style="display:flex;align-items:center;gap:8px;font-size:0.9rem;margin-bottom:12px;">
+            <input type="checkbox" id="d1-sync-enabled">
+            保存時に自動で Cloudflare に同期する
+          </label>
+          <button type="button" class="btn btn-primary btn-block" id="d1-sync-save-btn" style="justify-content:center;margin-bottom:8px;">設定を保存して今すぐ同期</button>
+          <button type="button" class="btn btn-secondary btn-block" id="d1-sync-pull-btn" style="justify-content:center;">クラウドから取得してローカルに反映</button>
+        </div>
+
         <div class="card">
           <h3 style="margin-bottom:16px;">🎨 テーマ設定</h3>
           <button class="btn btn-secondary btn-block" id="theme-toggle-btn" onclick="toggleTheme()" style="justify-content:center;">
@@ -340,6 +354,8 @@
   <script src="https://www.gstatic.com/firebasejs/10.14.0/firebase-firestore-compat.js" defer></script>
   <script src="js/firebase-config.js?v=1" defer></script>
   <script src="js/firebase-sync.js" defer></script>
+  <script src="js/d1-sync-config.js" defer></script>
+  <script src="js/d1-sync.js" defer></script>
   <script src="app.js" defer></script>
 </body>
 </html>

--- a/issues/draft-cloudflare-d1-sync.md
+++ b/issues/draft-cloudflare-d1-sync.md
@@ -1,0 +1,39 @@
+## 概要
+
+学習データを Firebase Firestore だけでなく、**JCSQE 専用の Cloudflare D1 + 専用 Worker** にも保存できるようにする。[ut-qms / Qraft](https://github.com/junichi-muraoka/ut-qms) の D1 とは **別インスタンス**・**別 Worker** として分離し、JCSQE 側で独立に運用する。
+
+## 目的
+
+- 学習データをブラウザ以外にも保持する第 2 経路を用意する（Firestore と並行運用可能）。
+- **エンドユーザーは Worker URL もトークンも入力しない**：運用者が `js/d1-sync-config.js` に Worker のベース URL だけ記載し、ユーザーは Google ログインだけで使える。
+- ut-qms とはコード・DB・API キーを混ぜず、**JCSQE 単位で運用**できるようにする。
+
+## スコープ
+
+- `cloudflare/jcsqe-sync-worker/`（Hono + jose ベース。`GET/PUT /api/study`、D1 マイグレーション、CORS 設定）
+- `.github/workflows/deploy-jcsqe-sync-worker.yml`（Secrets が揃っているときだけ自動デプロイ、未設定時は明示的に fail）
+- `js/d1-sync.js` + `js/d1-sync-config(.example).js`（設定タブの UI から有効化、saveData 後にデバウンス PUT、手動 Pull）
+- 設定タブに ☁️ Cloudflare D1 カードを追加（`d1-sync-enabled` / `d1-sync-save-btn` / `d1-sync-pull-btn` / `d1-sync-status`）
+- `sw.js` に新規 JS をプリキャッシュ、キャッシュ名 bump
+- `docs/jcsqe_cloudflare_d1_sync.md`（設計・運用手順）、`cloudflare/jcsqe-sync-worker/README.md`
+- `scripts/verify-oauth-client.js` + テスト（Google OAuth クライアント ID の突合。関連強化）
+
+## 認証モデル
+
+- `Authorization: Bearer <Firebase ID トークン>` を Worker で Google JWKS 検証し、`sub`（Firebase UID）を D1 の行キーに使用。
+- レガシー：`Bearer <SYNC_API_SECRET>` + `X-User-Id`（互換用）。新フロントは使用しない。
+
+## 受け入れ条件
+
+- [ ] `cloudflare/jcsqe-sync-worker/` 一式が commit され、`npm ci && npm run dev` がローカルで起動する。
+- [ ] 必要 Secrets（`D1_DATABASE_ID` / `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` / `FIREBASE_PROJECT_ID`）が揃っている場合、master への push で Worker が自動デプロイされる。
+- [ ] 設定タブに Cloudflare D1 同期カードが表示され、トグル ON + ログイン済みで `saveData` ごとに PUT される（手動 Pull も動く）。
+- [ ] Worker URL 未設定時はカードが無効状態になる（ユーザー向けメッセージ表示、エラー無し）。
+- [ ] `docs/jcsqe_cloudflare_d1_sync.md` と `cloudflare/jcsqe-sync-worker/README.md` の手順どおりにセットアップできる。
+- [ ] `npm test` が緑（OAuth 突合スクリプトのテスト含む）。
+
+## 非スコープ
+
+- Firestore ↔ D1 の二重同期ルールの厳密化（併存は可、マージ方針は既存仕様どおり）。
+- D1 のバックアップ・監視ダッシュボード（別 Issue）。
+- UI のデザインリニュー。

--- a/js/d1-sync-config.example.js
+++ b/js/d1-sync-config.example.js
@@ -1,0 +1,7 @@
+// このファイルを js/d1-sync-config.js にコピーし、デプロイした Worker のベース URL を 1 行だけ設定してください。
+// （末尾スラッシュなし。ユーザーが URL を入力する必要はありません）
+(function(global) {
+  'use strict';
+  const J = global.JCSQE = global.JCSQE || {};
+  J.d1SyncWorkerBaseUrl = 'https://jcsqe-study-sync.your-subdomain.workers.dev';
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/d1-sync-config.js
+++ b/js/d1-sync-config.js
@@ -1,0 +1,6 @@
+// Worker のベース URL（運用者がデプロイ後に 1 回だけ設定。空なら D1 同期は無効）
+(function(global) {
+  'use strict';
+  const J = global.JCSQE = global.JCSQE || {};
+  J.d1SyncWorkerBaseUrl = 'https://jcsqe-study-sync.j-muraoka-secure.workers.dev';
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/d1-sync.js
+++ b/js/d1-sync.js
@@ -1,0 +1,195 @@
+// Cloudflare Worker + D1 への自動同期（Firebase ID トークン認証。URL は js/d1-sync-config.js に運用者のみ記載）
+(function(global) {
+  'use strict';
+  const J = global.JCSQE = global.JCSQE || {};
+  const CONFIG_KEY = 'jcsqe_cf_sync_config_v2';
+  const LEGACY_KEY = 'jcsqe_cf_sync_config_v1';
+  const DEBOUNCE_MS = 3500;
+  let timer = null;
+  let syncingFromCloud = false;
+  let savePatched = false;
+
+  function getConfig() {
+    try {
+      const raw = localStorage.getItem(CONFIG_KEY);
+      if (raw) {
+        const o = JSON.parse(raw);
+        return { enabled: !!o.enabled };
+      }
+      const leg = localStorage.getItem(LEGACY_KEY);
+      if (leg) {
+        const o = JSON.parse(leg);
+        return { enabled: !!o.enabled };
+      }
+    } catch {
+      /* ignore */
+    }
+    return { enabled: false };
+  }
+
+  function saveConfig(c) {
+    localStorage.setItem(CONFIG_KEY, JSON.stringify({ enabled: !!c.enabled }));
+  }
+
+  function workerBaseUrl() {
+    const u = J.d1SyncWorkerBaseUrl;
+    return typeof u === 'string' ? u.trim().replace(/\/$/, '') : '';
+  }
+
+  function getFirebaseAuth() {
+    if (!global.firebase || !firebase.apps || firebase.apps.length === 0) return null;
+    try {
+      return firebase.auth();
+    } catch {
+      return null;
+    }
+  }
+
+  function getIdToken() {
+    const auth = getFirebaseAuth();
+    if (!auth || !auth.currentUser) return Promise.resolve(null);
+    return auth.currentUser.getIdToken(false);
+  }
+
+  function catalogOpts() {
+    if (typeof QUESTIONS !== 'undefined' && Array.isArray(QUESTIONS)) {
+      return { validQuestionIds: QUESTIONS.map(function(q) { return q.id; }) };
+    }
+    return undefined;
+  }
+
+  function setStatus(msg, isErr) {
+    const el = document.getElementById('d1-sync-status');
+    if (!el) return;
+    el.textContent = msg;
+    el.style.color = isErr ? 'var(--danger)' : 'var(--text-muted)';
+  }
+
+  function scheduleCloudPush() {
+    if (syncingFromCloud) return;
+    const c = getConfig();
+    if (!c.enabled || !workerBaseUrl()) return;
+    clearTimeout(timer);
+    timer = setTimeout(function() { pushCloud(); }, DEBOUNCE_MS);
+  }
+
+  function pushCloud() {
+    const c = getConfig();
+    if (!c.enabled || !workerBaseUrl()) return;
+    if (!J.loadData) return;
+    getIdToken().then(function(token) {
+      if (!token) {
+        setStatus('D1 同期には Firebase（Google）でログインしてください', true);
+        return;
+      }
+      const data = J.loadData();
+      const url = workerBaseUrl() + '/api/study';
+      return fetch(url, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + token
+        },
+        body: JSON.stringify({ data: data })
+      });
+    }).then(function(r) {
+      if (!r) return;
+      if (!r.ok) throw new Error(String(r.status));
+      setStatus('Cloudflare D1 に同期しました（' + new Date().toLocaleString('ja-JP') + '）');
+    }).catch(function() {
+      setStatus('D1 同期に失敗しました（ログイン・ネットワーク・Worker を確認）', true);
+    });
+  }
+
+  function pullCloud() {
+    if (!workerBaseUrl()) {
+      setStatus('Worker URL が未設定です（運用者向け: js/d1-sync-config.js）', true);
+      return;
+    }
+    setStatus('クラウドから取得中…');
+    getIdToken().then(function(token) {
+      if (!token) {
+        setStatus('取得には Firebase（Google）でログインしてください', true);
+        return null;
+      }
+      const url = workerBaseUrl() + '/api/study';
+      return fetch(url, {
+        method: 'GET',
+        headers: { 'Authorization': 'Bearer ' + token }
+      });
+    }).then(function(r) {
+      if (!r) return;
+      if (!r.ok) throw new Error(String(r.status));
+      return r.json();
+    }).then(function(body) {
+      if (!body) return;
+      if (body.data == null) {
+        setStatus('クラウドにデータがありません');
+        return;
+      }
+      const norm = window.StudyData && window.StudyData.normalizeStudyData;
+      if (!norm || !J.saveData) return;
+      syncingFromCloud = true;
+      try {
+        J.saveData(norm(body.data, catalogOpts()));
+        setStatus('クラウドのデータを反映しました。画面を確認してください。');
+        if (typeof global.refreshStudyUi === 'function') global.refreshStudyUi();
+        else if (typeof global.updateHomeStats === 'function') global.updateHomeStats();
+        if (typeof global.updateDashboardStats === 'function') global.updateDashboardStats();
+      } finally {
+        syncingFromCloud = false;
+      }
+    }).catch(function() {
+      setStatus('取得に失敗しました', true);
+    });
+  }
+
+  function patchSaveData() {
+    if (savePatched || !J.saveData) return;
+    const orig = J.saveData;
+    J.saveData = function(d) {
+      orig(d);
+      scheduleCloudPush();
+    };
+    savePatched = true;
+  }
+
+  function readForm() {
+    const enabled = !!(document.getElementById('d1-sync-enabled') || {}).checked;
+    return { enabled: enabled };
+  }
+
+  function applyFormToConfig() {
+    const f = readForm();
+    saveConfig({ enabled: f.enabled });
+  }
+
+  function saveD1SyncSettings() {
+    applyFormToConfig();
+    setStatus('設定を保存しました');
+    if (getConfig().enabled && workerBaseUrl()) {
+      pushCloud();
+    }
+  }
+
+  function initCard() {
+    const c = getConfig();
+    const enEl = document.getElementById('d1-sync-enabled');
+    if (enEl) enEl.checked = c.enabled;
+
+    const saveBtn = document.getElementById('d1-sync-save-btn');
+    const pullBtn = document.getElementById('d1-sync-pull-btn');
+    if (saveBtn) saveBtn.addEventListener('click', saveD1SyncSettings);
+    if (pullBtn) pullBtn.addEventListener('click', pullCloud);
+  }
+
+  global.saveD1SyncSettings = saveD1SyncSettings;
+  global.pullD1Sync = pullCloud;
+
+  patchSaveData();
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initCard);
+  } else {
+    initCard();
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jcsqe-study-app",
-  "version": "1.2.11",
+  "version": "1.2.24",
   "description": "JCSQE初級 合格対策学習アプリ",
   "private": true,
   "scripts": {

--- a/scripts/verify-oauth-client.js
+++ b/scripts/verify-oauth-client.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * GOOGLE_OAUTH_CLIENT_ID（GitHub Secret 等）と、firebase-config.js 内の
+ * J.googleOAuthClientId が一致するか検証する。
+ *
+ * 使い方:
+ *   GOOGLE_OAUTH_CLIENT_ID=xxx.apps.googleusercontent.com node scripts/verify-oauth-client.js _site/js/firebase-config.js
+ *   GOOGLE_OAUTH_CLIENT_ID=xxx VERIFY_REMOTE_URL=https://jcsqe-study-app.pages.dev node scripts/verify-oauth-client.js --remote
+ *
+ * GCP の「承認済み JavaScript 生成元」は公開 API が無く自動検証不可。
+ */
+'use strict';
+
+const fs = require('fs');
+
+const expected = process.env.GOOGLE_OAUTH_CLIENT_ID && String(process.env.GOOGLE_OAUTH_CLIENT_ID).trim();
+if (!expected) {
+  console.log('verify-oauth-client: GOOGLE_OAUTH_CLIENT_ID unset — skip.');
+  process.exit(0);
+}
+
+function extractId(source) {
+  const m = String(source).match(/J\.googleOAuthClientId\s*=\s*"([^"]*)"\s*;/);
+  return m ? m[1] : null;
+}
+
+function sleep(ms) {
+  return new Promise(function(resolve) {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function fetchConfigJs(baseUrl) {
+  const base = String(baseUrl).replace(/\/$/, '');
+  const attempts = parseInt(process.env.VERIFY_OAUTH_ATTEMPTS || '8', 10);
+  const delayMs = parseInt(process.env.VERIFY_OAUTH_DELAY_MS || '4000', 10);
+  let lastStatus = 0;
+  for (let i = 0; i < attempts; i++) {
+    const cfgPath = '/js/firebase-config.js';
+    const url = base + cfgPath + '?_v=' + Date.now();
+    const res = await fetch(url, { redirect: 'follow' });
+    lastStatus = res.status;
+    if (res.ok) return await res.text();
+    console.warn('verify-oauth-client: GET ' + url + ' → HTTP ' + res.status + ' (retry ' + (i + 1) + '/' + attempts + ')');
+    await sleep(delayMs);
+  }
+  throw new Error('Could not fetch firebase-config.js after retries (last HTTP ' + lastStatus + ')');
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  let body;
+  if (argv[0] === '--remote' || argv[0] === '-r') {
+    const base = process.env.VERIFY_REMOTE_URL || argv[1];
+    if (!base) {
+      console.error('verify-oauth-client: set VERIFY_REMOTE_URL or pass URL after --remote');
+      process.exit(1);
+    }
+    body = await fetchConfigJs(base);
+  } else {
+    const p = argv[0] || '_site/js/firebase-config.js';
+    if (!fs.existsSync(p)) {
+      console.error('verify-oauth-client: file not found: ' + p);
+      process.exit(1);
+    }
+    body = fs.readFileSync(p, 'utf8');
+  }
+
+  const found = extractId(body);
+  if (found === null) {
+    console.error('verify-oauth-client: could not parse J.googleOAuthClientId in firebase-config.js');
+    process.exit(1);
+  }
+
+  if (!/\.apps\.googleusercontent\.com$/.test(found)) {
+    console.error('verify-oauth-client: parsed client id does not look like a Web client ID:', found);
+    process.exit(1);
+  }
+
+  if (found !== expected) {
+    console.error('verify-oauth-client: MISMATCH');
+    console.error('  Secret GOOGLE_OAUTH_CLIENT_ID:  ' + expected);
+    console.error('  In firebase-config.js:         ' + found);
+    console.error(
+      'Fix: Firebase → Authentication → Google → ウェブ SDK 構成 の「ウェブ クライアント ID」をコピーし、GitHub Secret GOOGLE_OAUTH_CLIENT_ID をその値に更新してください。'
+    );
+    process.exit(1);
+  }
+
+  console.log('verify-oauth-client: OK — matches GOOGLE_OAUTH_CLIENT_ID');
+}
+
+main().catch(function(e) {
+  console.error('verify-oauth-client:', e.message || e);
+  process.exit(1);
+});

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,10 @@
 // 運用者が変える可能性がある firebase-config.js はプリキャッシュしない（常にネットワーク取得）
-const CACHE_NAME = 'jcsqe-v27';
+const CACHE_NAME = 'jcsqe-v28';
 const ASSETS = [
   './', './index.html', './style.css', './app.js',
   './js/storage.js', './js/state.js', './js/sync-firebase-errors.js',
   './js/firebase-sync.js',
+  './js/d1-sync.js',
   './questions.js', './questions_extra1.js', './questions_extra2.js', './questions_extra3.js', './questions_extra4.js',
   './explanations_extra.js', './explanations_exp3.js', './explanations.js', './glossary.js', './study-data.js', './manifest.json'
 ];

--- a/tests/verify-oauth-client.test.cjs
+++ b/tests/verify-oauth-client.test.cjs
@@ -1,0 +1,50 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const script = path.join(__dirname, '..', 'scripts', 'verify-oauth-client.js');
+
+const sampleSnippet =
+  '(function(global) {\n' +
+  "  const J = global.JCSQE = global.JCSQE || {};\n" +
+  '  J.firebaseConfig = {"apiKey":"k"};\n' +
+  '  J.googleOAuthClientId = "abc123-xyz.apps.googleusercontent.com";\n' +
+  '})(typeof window !== "undefined" ? window : globalThis);\n';
+
+test('local file: match exits 0', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'jcsqe-verify-oauth-'));
+  const fp = path.join(dir, 'firebase-config.js');
+  fs.writeFileSync(fp, sampleSnippet, 'utf8');
+  execFileSync(process.execPath, [script, fp], {
+    env: { ...process.env, GOOGLE_OAUTH_CLIENT_ID: 'abc123-xyz.apps.googleusercontent.com' },
+    encoding: 'utf8'
+  });
+});
+
+test('local file: mismatch exits non-zero', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'jcsqe-verify-oauth-'));
+  const fp = path.join(dir, 'firebase-config.js');
+  fs.writeFileSync(fp, sampleSnippet, 'utf8');
+  assert.throws(
+    () =>
+      execFileSync(process.execPath, [script, fp], {
+        env: { ...process.env, GOOGLE_OAUTH_CLIENT_ID: 'wrong.apps.googleusercontent.com' },
+        encoding: 'utf8'
+      }),
+    /MISMATCH/
+  );
+});
+
+test('GOOGLE_OAUTH_CLIENT_ID unset skips with exit 0', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'jcsqe-verify-oauth-'));
+  const fp = path.join(dir, 'firebase-config.js');
+  fs.writeFileSync(fp, sampleSnippet, 'utf8');
+  const env = { ...process.env };
+  delete env.GOOGLE_OAUTH_CLIENT_ID;
+  const out = execFileSync(process.execPath, [script, fp], { env, encoding: 'utf8' });
+  assert.match(out, /skip/i);
+});


### PR DESCRIPTION
## Summary

Closes #73

- **JCSQE 専用 Cloudflare D1 Sync Worker** を追加。ut-qms / Qraft の D1 とは**別インスタンス**・**別 Worker**。Firebase Firestore と並行する**任意の第 2 経路**として、学習データを JCSQE 独自の D1 にバックアップできる。
- 認証は **Firebase ID トークン**（Google JWKS で Worker 側検証、`sub` を D1 の行キーに）。運用者が `js/d1-sync-config.js` に Worker URL を 1 行書くだけでよく、**エンドユーザーは URL もトークンも入力しない**。
- 設定タブに ☁️ Cloudflare D1 同期カードを追加し、`saveData` 後のデバウンス PUT と手動 Pull が動く。
- `.github/workflows/deploy-jcsqe-sync-worker.yml` で自動デプロイ（Secrets 欠け時は明示 fail）。
- 関連強化：`scripts/verify-oauth-client.js` + テストで `GOOGLE_OAUTH_CLIENT_ID` と `firebase-config.js` の OAuth クライアント ID を突合（`npm test` 内で常時検査）。
- `sw.js` のキャッシュ名を `jcsqe-v28` に bump、`package.json` / CHANGELOG も 1.2.24 へ更新。

## 主な変更ファイル

- `cloudflare/jcsqe-sync-worker/`（Worker、D1 マイグレーション、wrangler.toml、package、README）
- `.github/workflows/deploy-jcsqe-sync-worker.yml`
- `js/d1-sync.js` / `js/d1-sync-config(.example).js`
- `index.html`（設定タブ UI + スクリプト読込）
- `sw.js`（プリキャッシュ + CACHE_NAME）
- `scripts/verify-oauth-client.js` + `tests/verify-oauth-client.test.cjs`
- `docs/jcsqe_cloudflare_d1_sync.md` / `CHANGELOG.md` / `package.json`

## 必要な Repository Secrets（未設定だと Worker のデプロイは明示 fail）

- `D1_DATABASE_ID`（`wrangler d1 create jcsqe-study-data` の UUID）
- `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`
- `FIREBASE_PROJECT_ID`（`firebase-config.js` の `projectId` と一致）
- 任意: `JCSQE_SYNC_API_SECRET`（レガシー Bearer 用。通常は空でよい）

## Test plan

- [x] `npm test`（ユニット + 問題整合性 + secret チェック + `verify-oauth-client` 突合）
- [ ] Merge 後、Actions の **Deploy JCSQE Sync Worker** が緑で完了することを確認
- [ ] デプロイ後、`GET /api/health` が `{ok:true}` を返す
- [ ] STG Pages の設定タブにカードが出て、Google ログイン中にトグル ON → 任意の問題を 1 問解いて `d1-sync-status` に「同期しました」メッセージが出る
- [ ] 「クラウドから取得」で同じユーザーのデータが復元できる
- [ ] `js/d1-sync-config.js` を空文字列にすると同期が発動しないことを確認
