### PR TITLE
fix(settings): 確定モードトグル文言の「選択肢」統一 (#84)

### DIFF
--- a/app.js
+++ b/app.js
@@ -672,10 +672,19 @@ if ('serviceWorker' in navigator) { navigator.serviceWorker.register('./sw.js').
 
   // ── 試験情報パネル (#15) ──
   const EXAM_SCHEDULE = [
-    { date: '2026-06-21', deadline: '2026-05-15', label: '第28回' },
-    { date: '2026-11-15', deadline: '2026-10-10', label: '第29回' },
-    { date: '2027-06-20', deadline: '2027-05-15', label: '第30回' },
+    { date: '2026-06-13T10:30:00+09:00', deadline: '2026-04-10T15:00:00+09:00', label: '第36回' },
+    { date: '2026-11-14T10:30:00+09:00', deadline: '2026-09-04T15:00:00+09:00', label: '第37回', tentative: true },
   ];
+  function formatScheduleDate(value, includeTime = false) {
+    const date = new Date(value);
+    const yyyy = date.getFullYear();
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const dd = String(date.getDate()).padStart(2, '0');
+    if (!includeTime) return `${yyyy}/${mm}/${dd}`;
+    const hh = String(date.getHours()).padStart(2, '0');
+    const min = String(date.getMinutes()).padStart(2, '0');
+    return `${yyyy}/${mm}/${dd} ${hh}:${min}`;
+  }
   function updateExamInfo() {
     const now = new Date();
     const next = EXAM_SCHEDULE.find(e => new Date(e.date) > now);
@@ -684,8 +693,8 @@ if ('serviceWorker' in navigator) { navigator.serviceWorker.register('./sw.js').
     const deadlineDate = new Date(next.deadline);
     const daysLeft = Math.ceil((examDate - now) / 86400000);
     const dlLeft = Math.ceil((deadlineDate - now) / 86400000);
-    document.getElementById('exam-date').textContent = next.date.replace(/-/g, '/') + ' (' + next.label + ')';
-    document.getElementById('exam-deadline').textContent = next.deadline.replace(/-/g, '/') + (dlLeft > 0 ? '' : ' (締切済)');
+    document.getElementById('exam-date').textContent = formatScheduleDate(next.date, true) + ' (' + next.label + ')';
+    document.getElementById('exam-deadline').textContent = formatScheduleDate(next.deadline, true) + (next.tentative ? '（予定）' : '') + (dlLeft > 0 ? '' : ' (締切済)');
     const cd = document.getElementById('exam-countdown');
     cd.textContent = '🔥 あと' + daysLeft + '日';
     if (dlLeft <= 7 && dlLeft > 0) document.getElementById('exam-deadline').textContent += ' ⚠️あと' + dlLeft + '日';
@@ -964,7 +973,7 @@ if ('serviceWorker' in navigator) { navigator.serviceWorker.register('./sw.js').
     // 試験日直前などで daysLeft が 0 になると 0 除算になり perDay が Infinity になるのを防ぐ
     const perDay = Math.max(Math.ceil(totalQs * 2 / Math.max(1, daysLeft)), 3); // 2周を目標
     let html = `<div style="margin-bottom:16px;">
-      <p><strong>📅 試験日:</strong> ${next.date} (${next.label})</p>
+      <p><strong>📅 試験日:</strong> ${formatScheduleDate(next.date, true)} (${next.label})</p>
       <p><strong>⏱️ 残り:</strong> ${daysLeft}日</p>
       <p><strong>🎯 目標:</strong> 全${totalQs}問を2周</p>
       <p><strong>📝 1日の目安:</strong> <span style="font-size:1.2rem;font-weight:900;color:var(--accent-light);">${perDay}問</span>/日</p>

--- a/app.js
+++ b/app.js
@@ -12,6 +12,43 @@ if ('serviceWorker' in navigator) { navigator.serviceWorker.register('./sw.js').
   let glossaryFlashcardItems = [];
   let glossaryFlashcardIdx = 0;
 
+  const QUIZ_CONFIRM_ANSWER_KEY = 'jcsqe_quiz_confirm_answer';
+
+  function isQuizConfirmAnswerEnabled() {
+    return localStorage.getItem(QUIZ_CONFIRM_ANSWER_KEY) === '1';
+  }
+
+  function usesQuizConfirmAnswerFlow() {
+    return state.mode !== 'mock' && isQuizConfirmAnswerEnabled();
+  }
+
+  function syncQuizConfirmSwitchDom() {
+    const sw = document.getElementById('quiz-confirm-answer-switch');
+    if (!sw) return;
+    const on = isQuizConfirmAnswerEnabled();
+    sw.setAttribute('aria-checked', String(on));
+    sw.classList.toggle('is-on', on);
+  }
+
+  function bindQuizConfirmSettingsUi() {
+    const sw = document.getElementById('quiz-confirm-answer-switch');
+    if (!sw || sw.dataset.bound === '1') return;
+    sw.dataset.bound = '1';
+    sw.addEventListener('click', () => {
+      const nextOn = !isQuizConfirmAnswerEnabled();
+      localStorage.setItem(QUIZ_CONFIRM_ANSWER_KEY, nextOn ? '1' : '0');
+      syncQuizConfirmSwitchDom();
+    });
+    syncQuizConfirmSwitchDom();
+  }
+
+  function bindQuizSubmitRow() {
+    const btn = document.getElementById('quiz-submit-btn');
+    if (!btn || btn.dataset.bound === '1') return;
+    btn.dataset.bound = '1';
+    btn.addEventListener('click', () => confirmQuizAnswer());
+  }
+
   // ── データ永続化 ──
   function resetData() {
     if (!confirm('学習データをすべてリセットしますか？')) return;
@@ -319,6 +356,22 @@ if ('serviceWorker' in navigator) { navigator.serviceWorker.register('./sw.js').
     document.getElementById('quiz-explanation').classList.add('hidden');
     document.getElementById('quiz-next-box').classList.add('hidden');
 
+    state.quizPendingChoice = null;
+    const confirmFlow = usesQuizConfirmAnswerFlow();
+    const submitRow = document.getElementById('quiz-submit-row');
+    const submitBtnEl = document.getElementById('quiz-submit-btn');
+    if (submitRow && submitBtnEl) {
+      if (confirmFlow) {
+        submitRow.classList.remove('hidden');
+        submitBtnEl.disabled = true;
+        submitBtnEl.setAttribute('aria-disabled', 'true');
+      } else {
+        submitRow.classList.add('hidden');
+        submitBtnEl.disabled = false;
+        submitBtnEl.removeAttribute('aria-disabled');
+      }
+    }
+
     const labels = ['A', 'B', 'C', 'D'];
     const container = document.getElementById('quiz-choices');
     container.innerHTML = '';
@@ -326,7 +379,7 @@ if ('serviceWorker' in navigator) { navigator.serviceWorker.register('./sw.js').
       const btn = document.createElement('button');
       btn.className = 'choice-btn';
       btn.innerHTML = `<span class="choice-label">${labels[i]}</span><span>${c}</span>`;
-      btn.onclick = () => selectAnswer(i);
+      btn.onclick = confirmFlow ? () => selectChoicePending(i) : () => commitAnswer(i);
       container.appendChild(btn);
     });
     updateBookmarkBtn();
@@ -338,18 +391,47 @@ if ('serviceWorker' in navigator) { navigator.serviceWorker.register('./sw.js').
     }
   }
 
-  function selectAnswer(chosen) {
+  function confirmQuizAnswer() {
+    if (!usesQuizConfirmAnswerFlow()) return;
+    if (state.quizPendingChoice === null || state.quizPendingChoice === undefined) return;
+    commitAnswer(state.quizPendingChoice);
+  }
+
+  function selectChoicePending(i) {
+    if (!usesQuizConfirmAnswerFlow()) return;
+    document.querySelectorAll('#quiz-choices .choice-btn').forEach((b, j) => {
+      b.classList.toggle('choice-selected', j === i);
+    });
+    state.quizPendingChoice = i;
+    const submitBtnEl = document.getElementById('quiz-submit-btn');
+    if (submitBtnEl) {
+      submitBtnEl.disabled = false;
+      submitBtnEl.removeAttribute('aria-disabled');
+    }
+  }
+
+  function commitAnswer(chosen) {
+    const quizConfirmActive = usesQuizConfirmAnswerFlow();
     const q = state.questions[state.idx];
     const correct = q.answer;
     const isCorrect = chosen === correct;
     const btns = document.querySelectorAll('.choice-btn');
 
     btns.forEach((btn, i) => {
+      btn.classList.remove('choice-selected');
       btn.classList.add('disabled');
       btn.onclick = null;
       if (i === correct) { btn.classList.add('correct'); btn.classList.add('flash'); }
       if (i === chosen && !isCorrect) { btn.classList.add('wrong'); btn.classList.add('shake'); }
     });
+
+    const submitRow = document.getElementById('quiz-submit-row');
+    const submitBtnEl = document.getElementById('quiz-submit-btn');
+    if (quizConfirmActive && submitRow && submitBtnEl) {
+      submitRow.classList.add('hidden');
+      submitBtnEl.disabled = true;
+      submitBtnEl.setAttribute('aria-disabled', 'true');
+    }
 
     if (isCorrect) state.score++;
     state.answers.push({ qid: q.id, chosen, correct: isCorrect });
@@ -766,13 +848,23 @@ if ('serviceWorker' in navigator) { navigator.serviceWorker.register('./sw.js').
     const screenId = activeScreen.id;
 
     if (screenId === 'quiz') {
+      const quizSubmitRowEl = document.getElementById('quiz-submit-row');
+      const quizSubmitBtnEl = document.getElementById('quiz-submit-btn');
+      const canConfirmPending = quizSubmitRowEl && !quizSubmitRowEl.classList.contains('hidden')
+        && quizSubmitBtnEl && !quizSubmitBtnEl.disabled;
+
+      if ((e.key === 'Enter' || e.key === ' ') && canConfirmPending) {
+        e.preventDefault();
+        confirmQuizAnswer();
+        return;
+      }
       // 1-4 で選択肢を選択
       if (['1','2','3','4'].includes(e.key)) {
         const btns = document.querySelectorAll('.choice-btn:not(.disabled)');
         const idx = parseInt(e.key) - 1;
         if (btns[idx]) btns[idx].click();
       }
-      // Enter/Space で次の問題
+      // Enter/Space で次の問題（確定済みのみ）
       if ((e.key === 'Enter' || e.key === ' ') && !document.getElementById('quiz-next-box').classList.contains('hidden')) {
         e.preventDefault();
         nextQuestion();
@@ -809,6 +901,8 @@ if ('serviceWorker' in navigator) { navigator.serviceWorker.register('./sw.js').
   updateHomeStats();
   updateExamInfo();
   initTheme();
+  bindQuizConfirmSettingsUi();
+  bindQuizSubmitRow();
   renderGlossary();
   generateStudyPlan();
 

--- a/docs/exam_meta.md
+++ b/docs/exam_meta.md
@@ -12,7 +12,7 @@
 
 | 内容 | リンク（例） |
 |------|----------------|
-| JCSQE（試験・申込などの案内） | [juse.jp / JCSQE 試験情報](https://www.juse.jp/jcsqe/exam/) |
+| JCSQE（試験・申込などの案内） | [juse.jp / JCSQE 開催情報・申込み](https://www.juse.jp/jcsqe/schedule/) |
 | JCSQE 資格制度のトップ | [juse.jp / JCSQE](https://www.juse.jp/jcsqe/) |
 
 ※ URL や試験要項は変更されることがあります。**受験前に必ず公式サイトで再確認**してください。

--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
             <div class="exam-info-item"><span class="exam-label">残り</span><span class="exam-value exam-countdown" id="exam-countdown">—</span></div>
           </div>
           <div class="exam-info-actions">
-            <a href="https://www.juse.jp/jcsqe/exam/" target="_blank" rel="noopener" class="btn btn-primary btn-sm">🔗 申込はこちら</a>
+            <a href="https://www.juse.jp/jcsqe/schedule/" target="_blank" rel="noopener" class="btn btn-primary btn-sm">🔗 公式情報を見る</a>
             <span class="exam-info-note">40問 / 60分 / 合格70%</span>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta name="theme-color" content="#0a0e1a">
   <link rel="manifest" href="manifest.json">
   <title>JCSQE初級 合格対策アプリ</title>
-  <link rel="stylesheet" href="style.css?v=21">
+  <link rel="stylesheet" href="style.css?v=22">
 </head>
 <body>
   <div id="sync-toast" class="sync-toast hidden" role="status" aria-live="polite"></div>
@@ -72,6 +72,9 @@
       <div class="progress-bar"><div class="progress-fill" id="quiz-bar" style="width:0%"></div></div>
       <p class="quiz-question" id="quiz-question"></p>
       <div class="choices" id="quiz-choices"></div>
+      <div id="quiz-submit-row" class="quiz-submit-row hidden">
+        <button type="button" class="btn btn-primary btn-block" id="quiz-submit-btn">回答する</button>
+      </div>
       <div id="quiz-explanation" class="explanation hidden">
         <h4>💡 解説</h4>
         <div id="quiz-explanation-text"></div>
@@ -286,6 +289,22 @@
           <button class="btn btn-secondary btn-block" id="theme-toggle-btn" onclick="toggleTheme()" style="justify-content:center;">
             <span id="theme-toggle" aria-hidden="true">🌙</span>&nbsp;<span id="theme-toggle-label">ライトモードに切替</span>
           </button>
+        </div>
+
+        <div class="card">
+          <h3 style="margin-bottom:16px;">📘 学習・出題の挙動</h3>
+          <div class="settings-quiz-behavior-row">
+            <button type="button"
+              class="settings-switch-thumb"
+              id="quiz-confirm-answer-switch"
+              role="switch"
+              aria-checked="false"
+              aria-labelledby="quiz-confirm-answer-switch-label"></button>
+            <div class="settings-quiz-behavior-copy">
+              <div id="quiz-confirm-answer-switch-label"><strong>肢を選んだあと、「回答する」で確定してから解説を表示</strong></div>
+              <p style="margin:8px 0 0;font-size:0.88rem;color:var(--text-secondary);line-height:1.5;">OFF のときは今までどおり、選択と同時に正解・解説を表示します。</p>
+            </div>
+          </div>
         </div>
 
         <div class="card">

--- a/js/state.js
+++ b/js/state.js
@@ -2,6 +2,10 @@
 (function(global) {
   'use strict';
   const J = global.JCSQE = global.JCSQE || {};
-  J.state = { mode: null, chapter: null, questions: [], idx: 0, score: 0, answers: [], timer: null, timeLeft: 0, sessionLimit: null };
+  J.state = {
+    mode: null, chapter: null, questions: [], idx: 0, score: 0, answers: [],
+    timer: null, timeLeft: 0, sessionLimit: null,
+    quizPendingChoice: null
+  };
   J.comboCount = 0;
 })(typeof window !== 'undefined' ? window : globalThis);

--- a/style.css
+++ b/style.css
@@ -213,6 +213,56 @@ body::before {
 .choice-btn.wrong .choice-label { background: var(--danger); color: #fff; }
 .choice-btn.disabled { cursor: default; opacity: 0.7; }
 .choice-btn.disabled.correct { opacity: 1; }
+.choice-btn.choice-selected:not(.correct):not(.wrong) {
+  border-color: var(--accent);
+  background: rgba(99,102,241,0.12);
+}
+
+/* クイズ「回答する」行 (#81) */
+.quiz-submit-row {
+  margin-top: 14px;
+}
+.quiz-submit-row.hidden {
+  display: none !important;
+}
+
+/* 設定: 確認してから回答 (#81) */
+.settings-quiz-behavior-row {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+}
+.settings-switch-thumb {
+  flex-shrink: 0;
+  position: relative;
+  width: 48px;
+  height: 28px;
+  border-radius: 999px;
+  border: 1px solid var(--border-glass);
+  background: rgba(255,255,255,0.06);
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition);
+  padding: 0;
+}
+.settings-switch-thumb::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--text-primary);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.35);
+  transition: transform var(--transition);
+}
+.settings-switch-thumb.is-on {
+  background: rgba(99,102,241,0.35);
+  border-color: var(--accent);
+}
+.settings-switch-thumb.is-on::after {
+  transform: translateX(20px);
+}
 
 /* Explanation */
 .explanation {

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // 運用者が変える可能性がある firebase-config.js はプリキャッシュしない（常にネットワーク取得）
-const CACHE_NAME = 'jcsqe-v28';
+const CACHE_NAME = 'jcsqe-v29';
 const ASSETS = [
   './', './index.html', './style.css', './app.js',
   './js/storage.js', './js/state.js', './js/sync-firebase-errors.js',

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -60,6 +60,42 @@ test.describe('JCSQE学習アプリ E2E', () => {
     await expect(page.locator('.exp-summary').first()).toBeVisible();
   });
 
+  test('「回答するで確定」ON のときは肢タップのみでは解説が出ず、確定後に解説へ進める (#81)', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('jcsqe_quiz_confirm_answer', '1');
+    });
+    await page.goto('/', { waitUntil: 'load' });
+    await clickNavCard(page, 'nav-daily');
+    await expect(page.locator('#quiz')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('#quiz-submit-row')).toBeVisible();
+    await expect(page.locator('#quiz-submit-btn')).toBeDisabled();
+    await page.locator('.choice-btn').first().click();
+    await expect(page.locator('#quiz-explanation')).toBeHidden();
+    await expect(page.locator('#quiz-submit-btn')).toBeEnabled();
+    await page.locator('#quiz-submit-btn').click();
+    await expect(page.locator('#quiz-explanation')).toBeVisible({ timeout: 4000 });
+
+    await page.locator('#quiz-next-btn').click();
+    await expect(page.locator('.choice-btn:not(.disabled)')).toHaveCount(4, { timeout: 8000 });
+    await page.locator('.choice-btn').nth(2).click();
+    await page.locator('#quiz-submit-btn').click();
+    await expect(page.locator('#quiz-explanation:not(.hidden)')).toBeVisible({ timeout: 4000 });
+  });
+
+  test('模擬試験では確定モードでも「回答する」は出ず1タップで進む (#81)', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('jcsqe_quiz_confirm_answer', '1');
+    });
+    await page.goto('/', { waitUntil: 'load' });
+    page.once('dialog', (dialog) => dialog.accept());
+    await clickNavCard(page, 'nav-mock');
+    await expect(page.locator('#quiz')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('#quiz-submit-row')).toBeHidden();
+    await page.locator('.choice-btn').first().click();
+    await expect(page.locator('#quiz-explanation')).toBeHidden();
+    await expect(page.locator('#quiz-progress')).toContainText('2', { timeout: 5000 });
+  });
+
   test('模擬試験モードでタイマーが表示される', async ({ page }) => {
     await page.goto('/', { waitUntil: 'load' });
     page.once('dialog', dialog => dialog.accept());

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -23,6 +23,15 @@ test.describe('JCSQE学習アプリ E2E', () => {
     await expect(plan).toContainText('1日の目安');
   });
 
+  test('試験情報パネルに公式日程と開催情報リンクが表示される', async ({ page }) => {
+    await page.clock.setFixedTime(new Date('2026-04-26T00:00:00+09:00'));
+    await page.goto('/', { waitUntil: 'load' });
+    const examInfo = page.locator('#exam-info');
+    await expect(examInfo.locator('#exam-date')).toContainText('2026/06/13 10:30 (第36回)');
+    await expect(examInfo.locator('#exam-deadline')).toContainText('2026/04/10 15:00 (締切済)');
+    await expect(examInfo.getByRole('link', { name: /公式情報を見る/ })).toHaveAttribute('href', 'https://www.juse.jp/jcsqe/schedule/');
+  });
+
   test('今日の5問をクリックしてクイズが開始される', async ({ page }) => {
     await page.goto('/', { waitUntil: 'load' });
     await clickNavCard(page, 'nav-daily');


### PR DESCRIPTION
closes #84

## 変更
- 「学習・出題の挙動」トグル文言を仕様どおり整理（[Issue #81](https://github.com/junichi-muraoka/jcsqe-study-app/issues/81) の本体と一致）
  - 「肢」を **選択肢** に統一
  - OFF 説明: **タップした時点**で **正誤判定と解説**
- Service Worker のプリキャッシュ名を **`jcsqe-v30`** に。

## Issue #81
GitHub Issue 側の §1 の表・§3・§5 も語彙を揃える edit を実施済み。

## #84 の完了チェック（実装側）
- [x] 「肢」単独を削除（「選択肢」で統一）
- [x] #81 と表示文言・仕様が矛盾しない
- [x] `npm test` OK
- [x] `npx playwright test tests/e2e.spec.js` OK
- [ ] マージ後、STG で設定画面を目視確認（担当）
